### PR TITLE
起動後，<C-d> を入力するとコアダンプになるバグに関連する修正

### DIFF
--- a/src/cmd/cmd.c
+++ b/src/cmd/cmd.c
@@ -1,7 +1,5 @@
 #include "cmd.h"
 
-cmd_t *cmd;
-
 const int8_t (*cmd_handler[NCMD])(uint32_t argc, char **argv) = {
   msh_echo,
   msh_exit,

--- a/src/cmd/cmd.h
+++ b/src/cmd/cmd.h
@@ -10,7 +10,7 @@
 #define CMDLEN   256
 #define USAGELEN 256
 #define DESCLEN  65536
-#define NOT_FOUND "%s: not found\n"
+#define NOT_FOUND "\e[31m%s: command not found\e[m\n"
 #define EXIT_CMD "exit"
 
 #define RET_NORMAL        0x00
@@ -25,7 +25,6 @@ extern int8_t msh_echo(uint32_t argc, char **argv);
 extern int8_t msh_exit(uint32_t argc, char **argv);
 extern int8_t msh_help(uint32_t argc, char **argv);
 
-extern cmd_t *cmd;
 extern const char cmds[NCMD][CMDLEN];
 extern const char cmd_usage[NCMD][USAGELEN];
 extern const char cmd_desc[NCMD][DESCLEN];

--- a/src/cmd/help.c
+++ b/src/cmd/help.c
@@ -4,17 +4,22 @@ int8_t msh_help(uint32_t argc, char **argv) {
   uint32_t i, j;
   int8_t found;
 
-  if (1 >= argc)
-    for (i = 0; i < NCMD; i++ )
+  if (1 >= argc) {
+    for (i = 0; i < NCMD; i++ ) {
+      fprintf(stdout, "\e[33m");
       fprintf(stdout, "%s\n", cmd_usage[i]);
-  else {
+      fprintf(stdout, "\e[m");
+    }
+  } else {
     for (i = 1; i < argc; i++) {
       found = 0;
 
       for (j = 0; j < NCMD; j++) {
         if (strcmp(argv[i], cmds[j]) == 0) {
+          fprintf(stdout, "\e[33m");
           fprintf(stdout, "%s: %s\n", cmds[j], cmd_usage[j]);
           fprintf(stdout, "%s\n", cmd_desc[j]);
+          fprintf(stdout, "\e[m");
 
           found = 1;
         }

--- a/src/common/getch.c
+++ b/src/common/getch.c
@@ -2,17 +2,15 @@
 
 int getch(void) {
   struct termios oldt, newt;
-  int ch;
+  int            ch;
 
   tcgetattr(STDIN_FILENO, &oldt);
 
-  newt = oldt;
+  newt          = oldt;
   newt.c_lflag &= ~(ICANON | ECHO);
 
   tcsetattr(STDIN_FILENO, TCSANOW, &newt);
-
   ch = fgetc(stdin);
-
   tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
 
   return ch;

--- a/src/line.c
+++ b/src/line.c
@@ -136,7 +136,7 @@ static void get_line(char *line) {
       fflush(stdout);
 
       strncpy(line, p->data, LINE_SIZE);
-      len = strnlen(line, LINE_SIZE);
+      len = strlen(line);
 
       fputs(line, stdout);
       fflush(stdout);

--- a/src/line.c
+++ b/src/line.c
@@ -1,4 +1,4 @@
-#include "msh.h"
+#include "line.h"
 
 #define LIST_SIZE 8
 
@@ -9,7 +9,6 @@ typedef struct _node_t {
 } node_t;
 static node_t *head;
 static node_t *tail;
-static char *line;
 
 void init_history(void) {
   head = NULL;
@@ -18,7 +17,8 @@ void init_history(void) {
 
 static node_t *create_node(char *data, node_t *prev, node_t *next) {
   node_t *p;
-  p = xmalloc(sizeof(node_t));
+
+  p       = xmalloc(sizeof(node_t));
   p->data = xmalloc(sizeof(char*) * LINE_SIZE);
 
   strncpy(p->data, data, LINE_SIZE);
@@ -32,7 +32,7 @@ static node_t *create_node(char *data, node_t *prev, node_t *next) {
 static int8_t delete_head_node(void) {
   node_t *p;
 
-  if (NULL == head)
+  if (head == NULL)
     return 1;
 
   p = head->next;
@@ -40,7 +40,7 @@ static int8_t delete_head_node(void) {
   free(head->data);
   free(head);
 
-  if (NULL != p)
+  if (p != NULL)
     p->prev = NULL;
 
   head = p;
@@ -53,7 +53,7 @@ void delete_history(void) {
 
   p = head;
 
-  while (NULL != head) {
+  while (head != NULL) {
     p = head->next;
 
     free(head->data);
@@ -65,9 +65,9 @@ void delete_history(void) {
 
 static void append_history(char *data) {
   static uint8_t size = 0;
-  node_t *p;
+  node_t        *p;
 
-  if (NULL == data || 0x00 == data[0])
+  if (data == NULL || data[0] == 0)
     return;
 
   if (size == LIST_SIZE)
@@ -75,76 +75,51 @@ static void append_history(char *data) {
 
   p = create_node(data, NULL, NULL);
 
-  if (NULL == tail)
+  if (tail == NULL)
     head = p;
   else {
-    p->prev = tail;
+    p->prev    = tail;
     tail->next = p;
   }
 
   tail = p;
-
   size += ((uint8_t)(size - LIST_SIZE) >> 7);
 }
 
+static void get_line(char *line) {
+  char    c;
+  node_t *p  = NULL;
+  size_t  len = 0;
 
-static char *get_line(void) {
-  node_t *p;
-  char c;
-  size_t len;
-
-  if (2 > LINE_SIZE) {
-    len = strlen(PROMPT);
-
-    while (0 < len) {
-      len--;
-      fputs("\b \b", stdout);
-    }
-    fflush(stdout);
-
-    fprintf(stderr,
-        "System Error: line buffer size is invalid [%lu]\n",
-        LINE_SIZE);
-    fflush(stdout);
-
-    delete_history();
-    free_cmd(cmd);
-
+  if (line == NULL) {
+    fprintf(stderr, "\e[31;1mline buffer is NULL\e[m\n");
     exit(1);
   }
 
-  p = NULL;
-  len = 0;
-  line = xmalloc(sizeof(char*) * LINE_SIZE);
-
   while (0x0a != (c = getch())) {
-    if (0 == len && 0x04 == c) {
-      free(line);
-      delete_history();
-      free_cmd(cmd);
-      fputc('\n', stdout);
-      fflush(stdout);
-      exit(0);
+    if (len == 0 && c == 0x04) {
+      strcpy(line, EXIT_CMD);
+      break;
     }
 
-    if (0x1b == c && 0x5b == getch()) {
-      if (0x41 == (c = getch())) {
-        if (NULL == tail)
+    if (c == 0x1b && getch() == 0x5b) {
+      if ((c = getch()) == 0x41) {
+        if (tail == NULL)
           continue;
-        if (NULL == p)
+        if (p == NULL)
           p = tail;
         else {
-          if (NULL == p->prev)
+          if (p->prev == NULL)
             continue;
           p = p->prev;
         }
-      } else if (0x42 == c) {
-        if (NULL == p)
+      } else if (c == 0x42) {
+        if (p == NULL)
           continue;
-        if (NULL == p->next) {
-          p = NULL;
-          line[0] = 0x00;
-          while (0 < len) {
+        if (p->next == NULL) {
+          p       = NULL;
+          line[0] = 0;
+          while (len > 0) {
             len--;
             fputs("\b \b", stdout);
           }
@@ -154,7 +129,7 @@ static char *get_line(void) {
         p = p->next;
       } else
         continue;
-      while (0 < len) {
+      while (len > 0) {
         len--;
         fputs("\b \b", stdout);
       }
@@ -165,36 +140,34 @@ static char *get_line(void) {
 
       fputs(line, stdout);
       fflush(stdout);
-    } else if (0 < len && 0x7f == c) {
+    } else if (len > 0 && c == 0x7f) {
       len--;
-      line[len] = 0x00;
+      line[len] = 0;
 
       fputs("\b \b", stdout);
       fflush(stdout);
-    } else if (0x20 <= c && 0x7e >= c) {
+    } else if (c >= 0x20 && c <= 0x7e) {
       fputc(c, stdout);
       fflush(stdout);
 
-      if (LINE_SIZE - 2 > len) {
-        line[len] = c;
-        line[len+1] = 0x00;
+      if (len < LINE_SIZE - 2) {
+        line[len]     = c;
+        line[len + 1] = 0;
         len++;
       }
-    } else
-      ;
+    }
   }
 
   fputc('\n', stdout);
   fflush(stdout);
-
-  return line;
 }
 
-char *get_cmd(void) {
-  char *p;
+void get_cmdline(char *line) {
+  if (line == NULL) {
+    fprintf(stderr, "\e[31;1mline buffer is NULL\e[m\n");
+    exit(1);
+  }
 
-  p = get_line();
-  append_history(p);
-
-  return p;
+  get_line(line);
+  append_history(line);
 }

--- a/src/line.h
+++ b/src/line.h
@@ -1,10 +1,23 @@
 #ifndef _LINE_H_
 #define _LINE_H_
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "cmd/cmd.h"
+#include "common/getch.h"
+#include "common/utils.h"
+
 #define LINE_SIZE 80UL
 
 extern void init_history(void);
 extern void delete_history(void);
-extern char *get_cmd(void);
+extern void get_cmdline(char *line);
 
 #endif

--- a/src/line.h
+++ b/src/line.h
@@ -1,10 +1,6 @@
 #ifndef _LINE_H_
 #define _LINE_H_
 
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
-
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/msh.c
+++ b/src/msh.c
@@ -3,14 +3,15 @@
 int main(int argc, char **argv) {
   int     opt;
   uint8_t copt = 0;
-  int8_t  ret;
-  char   *line;
+  int8_t  ret  = 0;
+  char   *line = NULL;
+  cmd_t  *cmd  = NULL;
 
   while ((opt = getopt(argc, argv, "c:h")) != -1) {
     switch (opt) {
       case 'c':
         copt = 1;
-        line = xmalloc(sizeof(char*) * LINE_SIZE);
+        line = xmalloc(sizeof(char *) * LINE_SIZE);
         strncpy(line, optarg, LINE_SIZE);
         break;
       case 'h':
@@ -30,13 +31,12 @@ int main(int argc, char **argv) {
       if (strcmp(EXIT_CMD, cmd->argv[0]) == 0) {
         free(line);
         free_cmd(cmd);
-        exit(ret);
+        return ret;
       } else if (ret == RET_NOT_FOUND) {
         fprintf(stdout, NOT_FOUND, cmd->argv[0]);
         fflush(stdout);
       }
     }
-
     free(line);
     free_cmd(cmd);
   } else {
@@ -46,23 +46,27 @@ int main(int argc, char **argv) {
       fprintf(stdout, "%s", PROMPT);
       fflush(stdout);
 
-      cmd = parse_cmd(get_cmd());
+      line = xmalloc(sizeof(char *) * LINE_SIZE);
+      get_cmdline(line);
+      cmd = parse_cmd(line);
 
       if (cmd->argc > 0) {
         ret = exec_cmd(cmd);
 
         if (strcmp(EXIT_CMD, cmd->argv[0]) == 0) {
+          free(line);
           free_cmd(cmd);
           delete_history();
-          return ret;
-        } else if (ret == RET_NOT_FOUND) {
+          break;
+        }
+        if (ret == RET_NOT_FOUND) {
           fprintf(stdout, NOT_FOUND, cmd->argv[0]);
           fflush(stdout);
         }
       }
+      free(line);
       free_cmd(cmd);
     }
   }
-
-  return 0;
+  return ret;
 }

--- a/src/msh.h
+++ b/src/msh.h
@@ -1,10 +1,6 @@
 #ifndef _MSH_H_
 #define _MSH_H_
 
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
-
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/parse.c
+++ b/src/parse.c
@@ -1,22 +1,23 @@
-#include "msh.h"
+#include "parse.h"
 
 #define INIT_CAPA 8
 
 cmd_t *parse_cmd(char *line) {
+  cmd_t   *cmd;
   char    *p    = line;
   uint32_t capa = INIT_CAPA;
 
-  cmd           = xmalloc(sizeof(cmd_t));
-  cmd->argc     = 0;
-  cmd->argv     = xmalloc(sizeof(char*) * capa);
+  cmd       = xmalloc(sizeof(cmd_t));
+  cmd->argc = 0;
+  cmd->argv = xmalloc(sizeof(char *) * capa);
 
   while (*p) {
     while (*p && 0x20 == *p)
       *p++ = 0x00;
 
     if (*p) {
-      if (capa <= cmd->argc + 1) {
-        capa *= 2;
+      if (cmd->argc + 1 >= capa) {
+        capa     *= 2;
         cmd->argv = xrealloc(cmd->argv, sizeof(char*) * capa);
       }
 
@@ -26,7 +27,8 @@ cmd_t *parse_cmd(char *line) {
     while (*p && 0x20 != *p)
       p++;
   }
-  cmd->argv[cmd->argc] = 0x00;
+  cmd->argv[cmd->argc] = NULL;
+
   return cmd;
 }
 

--- a/src/parse.h
+++ b/src/parse.h
@@ -1,6 +1,12 @@
 #ifndef _PARSE_H_
 #define _PARSE_H_
 
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "cmd/cmd.h"
+#include "common/utils.h"
+
 extern cmd_t *parse_cmd(char *line);
 extern int8_t exec_cmd(cmd_t *cmd);
 extern void   free_cmd(cmd_t *cmd);


### PR DESCRIPTION
### 概要

`./build/msh` を実行後，<C-d> を入力すると コアダンプになるバグの修正，およびそれに関連したいくつかの修正．

### 変更点

- コマンドラインバッファ変数 `line` とコマンド構造体 `cmd` をグローバル変数からローカル変数に変更し，引数で受け渡しするように変更した．
こうすることで，メモリの確保と解放を変数宣言した関数で一括で行うことができ，メモリの解放漏れ等のリスクが低減した．
- [opt] コーディングスタイルを統一した
- [opt] `help` コマンドと `command not found` の出力に色を付けた
- [opt] すべてのコードで `msh.h` を `include` していたが，コードの独立性を向上させるため，コード毎に必要なヘッダーを `include` するようにした
- [opt] `strnlen` から `strlen` を使用するようにした

### Related Issue

#3 